### PR TITLE
Fixed typos in autodiff_remat.ipynb

### DIFF
--- a/docs/notebooks/autodiff_remat.ipynb
+++ b/docs/notebooks/autodiff_remat.ipynb
@@ -203,7 +203,7 @@
     "id": "40oy-FbmVkDc"
    },
    "source": [
-    "When playing around with these toy examples, we can get a closer look at what's going on using the `print_fwd_bwd` utility definied in this notebook:"
+    "When playing around with these toy examples, we can get a closer look at what's going on using the `print_fwd_bwd` utility defined in this notebook:"
    ]
   },
   {
@@ -359,7 +359,7 @@
     "\n",
     "\n",
     "\n",
-    "In both `jax.linearize` and `jax.vjp` there is flexibilty in how and when some values are computed. Different choices can trade off memory use against FLOPs. JAX provides control over these choices with `jax.checkpoint`.\n",
+    "In both `jax.linearize` and `jax.vjp` there is flexibility in how and when some values are computed. Different choices can trade off memory use against FLOPs. JAX provides control over these choices with `jax.checkpoint`.\n",
     "\n",
     "One such choice is whether to perform Jacobian coefficient computations on the forward pass, as soon as the inputs are available, or on the backward pass, just before the coefficients are needed. Consider the example of `sin_vjp`:"
    ]


### PR DESCRIPTION
fixed using https://github.com/crate-ci/typos